### PR TITLE
Fix breaking change to postfix sasl_auth config in postfix>5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+## 0.4.1 (2018-08-29)
 * Require postfix > 5.3 and implement fix for the breaking change to their sasl_auth config attributes
   in that version : throws exception if still defined and non-empty in your project (see 
   chef-cookbooks/postfix#134). Fix spotted by @PeterGrace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+* Require postfix > 5.3 and implement fix for the breaking change to their sasl_auth config attributes
+  in that version : throws exception if still defined and non-empty in your project (see 
+  chef-cookbooks/postfix#134). Fix spotted by @PeterGrace.
+
 ## 0.4.0 (2017-08-10)
 * Ignore build-time files from the vendored cookbook
 * Update build dependencies and build against Chef 12 and Chef 13 (drops support for < 12.18.31)

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,4 +13,4 @@ source_url 'https://github.com/ingenerator/chef-postfix-relay'
   supports os
 end
 
-depends "postfix", "~>5.0"
+depends "postfix", "~>5.3"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache-2.0'
 chef_version '>=12.18.31'
 description 'Installs postfix as a local mail relay, optionally delivering all mail to local dump files (for dev/build servers)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.0'
+version '0.4.1'
 issues_url 'https://github.com/ingenerator/chef-postfix-relay/issues'
 source_url 'https://github.com/ingenerator/chef-postfix-relay'
 

--- a/recipes/install_remote_relay.rb
+++ b/recipes/install_remote_relay.rb
@@ -20,11 +20,19 @@
 # limitations under the License.
 #
 
+%w(smtp_sasl_user_name smtp_sasl_passwd).each do | legacy_attr |
+  if node['postfix']['sasl'] && node['postfix']['sasl'][legacy_attr]
+    raise ArgumentError.new(
+      "Unexpected value for node.postfix.sasl.#{legacy_attr} : this syntax is no longer supported by the postfix cookbook"
+    )
+  end
+end
 
 # Set postfix access credentials
-node.normal['postfix']['main']['relayhost']           = node['postfix_relay']['live_email']['relayhost']
-node.normal['postfix']['sasl']['smtp_sasl_passwd']    = node['postfix_relay']['live_email']['smtp_sasl_passwd']
-node.normal['postfix']['sasl']['smtp_sasl_user_name'] = node['postfix_relay']['live_email']['smtp_sasl_user_name']
+relayhost = node['postfix_relay']['live_email']['relayhost']
+node.normal['postfix']['main']['relayhost']           = relayhost
+node.normal['postfix']['sasl'][relayhost]['smtp_sasl_passwd']    = node['postfix_relay']['live_email']['smtp_sasl_passwd']
+node.normal['postfix']['sasl'][relayhost]['smtp_sasl_user_name'] = node['postfix_relay']['live_email']['smtp_sasl_user_name']
 
 # Ensure that outgoing mail without a domain (eg from local users) is in the correct domain
 node.normal['postfix']['main']['myhostname']          = node['postfix_relay']['email_domain']


### PR DESCRIPTION
Per chef-cookbooks/postfix#134, the 5.3.0 release has a non-advertised
breaking change that requires different config attributes for the sasl_auth
for remote relays. @PeterGrace fixed this in his fork : merged back here with
an additional sanity check to throw if (unexpectedly) a project defines an
explicit value for these config attributes.