### PR TITLE
Fix naming of username and password attribute for new sasl_auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+* Fix provisioning sasl_auth with the new attribute structure : attributes have been renamed as 
+  well as moved about. No longer throw if old-style attributes are set - these may be set in a 
+  persisted node object from a previous run : we just need to delete them.
+
 ## 0.4.1 (2018-08-29)
 * Require postfix > 5.3 and implement fix for the breaking change to their sasl_auth config attributes
   in that version : throws exception if still defined and non-empty in your project (see 

--- a/recipes/install_remote_relay.rb
+++ b/recipes/install_remote_relay.rb
@@ -31,8 +31,8 @@ end
 # Set postfix access credentials
 relayhost = node['postfix_relay']['live_email']['relayhost']
 node.normal['postfix']['main']['relayhost']           = relayhost
-node.normal['postfix']['sasl'][relayhost]['smtp_sasl_passwd']    = node['postfix_relay']['live_email']['smtp_sasl_passwd']
-node.normal['postfix']['sasl'][relayhost]['smtp_sasl_user_name'] = node['postfix_relay']['live_email']['smtp_sasl_user_name']
+node.normal['postfix']['sasl'][relayhost]['password'] = node['postfix_relay']['live_email']['smtp_sasl_passwd']
+node.normal['postfix']['sasl'][relayhost]['username'] = node['postfix_relay']['live_email']['smtp_sasl_user_name']
 
 # Ensure that outgoing mail without a domain (eg from local users) is in the correct domain
 node.normal['postfix']['main']['myhostname']          = node['postfix_relay']['email_domain']

--- a/recipes/install_remote_relay.rb
+++ b/recipes/install_remote_relay.rb
@@ -20,19 +20,19 @@
 # limitations under the License.
 #
 
-%w(smtp_sasl_user_name smtp_sasl_passwd).each do | legacy_attr |
-  if node['postfix']['sasl'] && node['postfix']['sasl'][legacy_attr]
-    raise ArgumentError.new(
-      "Unexpected value for node.postfix.sasl.#{legacy_attr} : this syntax is no longer supported by the postfix cookbook"
-    )
-  end
-end
-
+#
 # Set postfix access credentials
 relayhost = node['postfix_relay']['live_email']['relayhost']
 node.normal['postfix']['main']['relayhost']           = relayhost
 node.normal['postfix']['sasl'][relayhost]['password'] = node['postfix_relay']['live_email']['smtp_sasl_passwd']
 node.normal['postfix']['sasl'][relayhost]['username'] = node['postfix_relay']['live_email']['smtp_sasl_user_name']
+
+# Remove legacy postfix auth attributes, if any, to prevent them appearing in the rendered template
+# NB this doesn't actually remove the attributes yet because the postfix cookbook is still (brokenly)
+# creating them as empty values.
+# See https://github.com/chef-cookbooks/postfix/issues/148
+node.rm('postfix', 'sasl', 'smtp_sasl_user_name')
+node.rm('postfix', 'sasl', 'smtp_sasl_passwd')
 
 # Ensure that outgoing mail without a domain (eg from local users) is in the correct domain
 node.normal['postfix']['main']['myhostname']          = node['postfix_relay']['email_domain']

--- a/spec/install_remote_relay_spec.rb
+++ b/spec/install_remote_relay_spec.rb
@@ -63,17 +63,19 @@ describe 'postfix-relay::install_remote_relay' do
   context 'with invalid legacy stmp_sasl_passwd defined' do
     let (:postfix_sasl_attrs) { {'smtp_sasl_passwd' => 'anything'} }
 
-    it 'throws an exception' do
-      expect { chef_run }.to raise_exception(ArgumentError, /smtp_sasl_passwd/)
+    it 'clears the attribute' do
+      # Can't verify the key doesn't exist because the postfix cookbook recreates it with an empty string value
+      expect(chef_run.node['postfix']['sasl']['smtp_sasl_passwd']).to eq('')
     end
   end
 
-  context 'with invalid legacy stmp_sasl_user defined' do
+  context 'with invalid legacy stmp_sasl_user_name defined' do
     let (:postfix_sasl_attrs) { {'smtp_sasl_user_name' => 'anything'} }
 
-    it 'throws an exception' do
-      expect { chef_run }.to raise_exception(ArgumentError, /smtp_sasl_user_name/)
+    it 'clears the attribute' do
+      expect(chef_run.node['postfix']['sasl']['smtp_sasl_user_name']).to eq('')
     end
+
   end
 
 end

--- a/spec/install_remote_relay_spec.rb
+++ b/spec/install_remote_relay_spec.rb
@@ -42,8 +42,8 @@ describe 'postfix-relay::install_remote_relay' do
 
   it "sets the postfix relay configuration to use the configured remote host with credentials" do
     expect(chef_run.node['postfix']['main']['relayhost']).to eq('smtp.mydomain.com')
-    expect(chef_run.node['postfix']['sasl']['smtp.mydomain.com']['smtp_sasl_user_name']).to eq('me@mydomain.com')
-    expect(chef_run.node['postfix']['sasl']['smtp.mydomain.com']['smtp_sasl_passwd']).to eq('password')
+    expect(chef_run.node['postfix']['sasl']['smtp.mydomain.com']['username']).to eq('me@mydomain.com')
+    expect(chef_run.node['postfix']['sasl']['smtp.mydomain.com']['password']).to eq('password')
   end
   
   it "defaults to using postfix-relay TLS configuration for postfix attributes" do


### PR DESCRIPTION
The version from @PeterGrace didn't notice that the postfix cookbook
has also renamed these attributes so was generating invalid auth files